### PR TITLE
adds data-menu-offset to list of attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ which results in
 <div id="foo" data-anchor-target="#bar"></div>
 ```
 
-Supported attributes are: `data-anchor-target`, `data-smooth-scrolling` and `data-emit-events`.
+Supported attributes are: `data-anchor-target`, `data-smooth-scrolling`, `data-emit-events`, and `data-menu-offset`.
 
 
 Media queries

--- a/src/skrollr.stylesheets.js
+++ b/src/skrollr.stylesheets.js
@@ -24,7 +24,7 @@
 	var rxAnimationUsage = /-skrollr-animation-name\s*:\s*([\w-]+)/g;
 
 	//Finds usages of attribute setters.
-	var rxAttributeSetter = /-skrollr-(anchor-target|smooth-scrolling|emit-events)\s*:\s*['"]([^'"]+)['"]/g;
+	var rxAttributeSetter = /-skrollr-(anchor-target|smooth-scrolling|emit-events|menu-offset)\s*:\s*['"]([^'"]+)['"]/g;
 
 	var fetchRemote = function(url) {
 		var xhr = new XMLHttpRequest();


### PR DESCRIPTION
Hi -- we are trying to add data-menu-offset to multiple elements on our page. This change seems to work fine for us. Any reason you can think of to not include this?
