### PR TITLE
Circumvent problems (see #46) with SASS (>3.4) by allowing keyframes to be prefixed

### DIFF
--- a/src/skrollr.stylesheets.js
+++ b/src/skrollr.stylesheets.js
@@ -20,6 +20,9 @@
 	//Gets a single keyframe and the properties inside.
 	var rxSingleKeyframe = /([\w\-]+)\s*\{([^}]+)\}/g;
 
+	//Optional keyframe name prefix to work around SASS (>3.4) issues
+	var keyframeNameOptionalPrefix = 'skrollr-';
+
 	//Finds usages of the animation.
 	var rxAnimationUsage = /-skrollr-animation-name\s*:\s*([\w-]+)/g;
 
@@ -187,6 +190,7 @@
 		var elements;
 		var keyframes;
 		var keyframeName;
+		var cleanKeyframeName;
 		var elementIndex;
 		var attributeName;
 		var attributeValue;
@@ -202,9 +206,15 @@
 			keyframes = animations[selectors[selectorIndex][1]];
 
 			for(keyframeName in keyframes) {
+				cleanKeyframeName = keyframeName;
+
+				if (keyframeName.indexOf(keyframeNameOptionalPrefix) === 0) {
+					cleanKeyframeName = keyframeName.substring(keyframeNameOptionalPrefix.length);
+				}
+
 				for(elementIndex = 0; elementIndex < elements.length; elementIndex++) {
 					curElement = elements[elementIndex];
-					attributeName = 'data-' + keyframeName;
+					attributeName = 'data-' + cleanKeyframeName;
 					attributeValue = keyframes[keyframeName];
 
 					//If the element already has this keyframe inline, give the inline one precedence by putting it on the right side.

--- a/test/index.html
+++ b/test/index.html
@@ -25,6 +25,10 @@
 		-skrollr-animation-name: test3;
 	}
 
+	#prefixed {
+		-skrollr-animation-name: testprefixed;
+	}
+
 	@-skrollr-keyframes test1 {
 		bottom-top {
 			left:100%;
@@ -58,6 +62,15 @@
 		}
 	}
 
+	@-skrollr-keyframes testprefixed {
+		skrollr-0 {
+			left:0px;
+		}
+		skrollr-100 {
+			left:100px;
+		}
+	}
+
 	#precedence {
 		-skrollr-animation-name:precedence2;
 	}
@@ -86,6 +99,8 @@
 <body>
 	<div id="simple1"></div>
 	<div id="simple2"></div>
+
+	<div id="prefixed"></div>
 
 	<div id="complex1" class="complex"></div>
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -9,6 +9,13 @@ test('Elements with ID selector', function() {
 	equal(simple2.attr('data-bottom'), 'margin:100px;color:rgb(255,255,255);', '#simple2 bottom');
 });
 
+test('Elements with prefixed keyframes', function() {
+	var prefixed = $('#prefixed');
+
+	equal(prefixed.attr('data-0'), 'left:0px;', '#prefixed 0');
+	equal(prefixed.attr('data-100'), 'left:100px;', '#prefixed 100');
+});
+
 test('Elements with complex selectors', function() {
 	var complex1 = $('#complex1');
 


### PR DESCRIPTION
Default (optional) prefix for keyframes is "skrollr-".

Something like this in your CSS/SCSS would work:

```
@-skrollr-keyframes testprefixed {
    skrollr-0 {
        left:0px;
    }
    skrollr-100 {
        left:100px;
    }
}
```

SASS > 3.4 only seems to complain about keyframes that start with a digit.
